### PR TITLE
Upgrade to go 1.18 and reduce memory allocs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/gotracker/gomixing
 
-go 1.15
+go 1.18

--- a/mixing/panmixer.go
+++ b/mixing/panmixer.go
@@ -1,8 +1,6 @@
 package mixing
 
 import (
-	"math"
-
 	"github.com/gotracker/gomixing/panning"
 	"github.com/gotracker/gomixing/volume"
 )
@@ -10,74 +8,7 @@ import (
 // PanMixer is a mixer that's specialized for mixing multichannel audio content
 type PanMixer interface {
 	GetMixingMatrix(panning.Position) volume.Matrix
-	Channels() int
-}
-
-var (
-	// PanMixerMono is a mixer that's specialized for mixing monaural audio content
-	PanMixerMono PanMixer = &panMixerMono{}
-
-	// PanMixerStereo is a mixer that's specialized for mixing stereo audio content
-	PanMixerStereo PanMixer = &panMixerStereo{}
-
-	// PanMixerQuad is a mixer that's specialized for mixing quadraphonic audio content
-	PanMixerQuad PanMixer = &panMixerQuad{}
-)
-
-type panMixerMono struct {
-	PanMixer
-}
-
-func (p panMixerMono) GetMixingMatrix(pan panning.Position) volume.Matrix {
-	// distance and angle are ignored on mono
-	return volume.Matrix{1.0}
-}
-
-func (p panMixerMono) Channels() int {
-	return 1
-}
-
-type panMixerStereo struct {
-	PanMixer
-}
-
-func (p panMixerStereo) GetMixingMatrix(pan panning.Position) volume.Matrix {
-	pangle := float64(pan.Angle)
-	s, c := math.Sincos(pangle)
-	var d volume.Volume
-	if pan.Distance > 0 {
-		d = 1 / volume.Volume(pan.Distance*pan.Distance)
-	}
-	l := d * volume.Volume(s)
-	r := d * volume.Volume(c)
-	return volume.Matrix{l, r}
-}
-
-func (p panMixerStereo) Channels() int {
-	return 2
-}
-
-type panMixerQuad struct {
-	PanMixer
-}
-
-func (p panMixerQuad) GetMixingMatrix(pan panning.Position) volume.Matrix {
-	pangle := float64(pan.Angle)
-	sf, cf := math.Sincos(pangle)
-	sr, cr := math.Sin(pangle+math.Pi/2.0), math.Cos(pangle-math.Pi/2.0)
-	var d volume.Volume
-	if pan.Distance > 0 {
-		d = 1 / volume.Volume(pan.Distance*pan.Distance)
-	}
-	lf := d * volume.Volume(sf)
-	rf := d * volume.Volume(cf)
-	lr := d * volume.Volume(cr)
-	rr := d * volume.Volume(sr)
-	return volume.Matrix{lf, rf, lr, rr}
-}
-
-func (p panMixerQuad) Channels() int {
-	return 4
+	NumChannels() int
 }
 
 // GetPanMixer returns the panning mixer that can generate a matrix

--- a/mixing/panmixer_mono.go
+++ b/mixing/panmixer_mono.go
@@ -1,0 +1,23 @@
+package mixing
+
+import (
+	"github.com/gotracker/gomixing/panning"
+	"github.com/gotracker/gomixing/volume"
+)
+
+// PanMixerMono is a mixer that's specialized for mixing monaural audio content
+var PanMixerMono PanMixer = &panMixerMono{}
+
+type panMixerMono volume.Matrix
+
+func (p panMixerMono) GetMixingMatrix(pan panning.Position) volume.Matrix {
+	// distance and angle are ignored on mono
+	return volume.Matrix{
+		StaticMatrix: volume.StaticMatrix{1.0},
+		Channels:     1,
+	}
+}
+
+func (p panMixerMono) NumChannels() int {
+	return p.Channels
+}

--- a/mixing/panmixer_quad.go
+++ b/mixing/panmixer_quad.go
@@ -1,0 +1,35 @@
+package mixing
+
+import (
+	"math"
+
+	"github.com/gotracker/gomixing/panning"
+	"github.com/gotracker/gomixing/volume"
+)
+
+// PanMixerQuad is a mixer that's specialized for mixing quadraphonic audio content
+var PanMixerQuad PanMixer = &panMixerQuad{}
+
+type panMixerQuad volume.Matrix
+
+func (p panMixerQuad) GetMixingMatrix(pan panning.Position) volume.Matrix {
+	pangle := float64(pan.Angle)
+	sf, cf := math.Sincos(pangle)
+	sr, cr := math.Sin(pangle+math.Pi/2.0), math.Cos(pangle-math.Pi/2.0)
+	var d volume.Volume
+	if pan.Distance > 0 {
+		d = 1 / volume.Volume(pan.Distance*pan.Distance)
+	}
+	lf := d * volume.Volume(sf)
+	rf := d * volume.Volume(cf)
+	lr := d * volume.Volume(cr)
+	rr := d * volume.Volume(sr)
+	return volume.Matrix{
+		StaticMatrix: volume.StaticMatrix{lf, rf, lr, rr},
+		Channels:     4,
+	}
+}
+
+func (p panMixerQuad) NumChannels() int {
+	return p.Channels
+}

--- a/mixing/panmixer_stereo.go
+++ b/mixing/panmixer_stereo.go
@@ -1,0 +1,32 @@
+package mixing
+
+import (
+	"math"
+
+	"github.com/gotracker/gomixing/panning"
+	"github.com/gotracker/gomixing/volume"
+)
+
+// PanMixerStereo is a mixer that's specialized for mixing stereo audio content
+var PanMixerStereo PanMixer = &panMixerStereo{}
+
+type panMixerStereo volume.Matrix
+
+func (p panMixerStereo) GetMixingMatrix(pan panning.Position) volume.Matrix {
+	pangle := float64(pan.Angle)
+	s, c := math.Sincos(pangle)
+	var d volume.Volume
+	if pan.Distance > 0 {
+		d = 1 / volume.Volume(pan.Distance*pan.Distance)
+	}
+	l := d * volume.Volume(s)
+	r := d * volume.Volume(c)
+	return volume.Matrix{
+		StaticMatrix: volume.StaticMatrix{l, r},
+		Channels:     2,
+	}
+}
+
+func (p panMixerStereo) NumChannels() int {
+	return p.Channels
+}

--- a/sampling/samplerimpl.go
+++ b/sampling/samplerimpl.go
@@ -19,7 +19,7 @@ func (s *sampler) Advance() {
 
 func (s *sampler) GetSample() volume.Matrix {
 	if s.ss == nil {
-		return nil
+		return volume.Matrix{}
 	}
 	return s.ss.GetSample(s.pos)
 }

--- a/volume/matrix.go
+++ b/volume/matrix.go
@@ -1,0 +1,153 @@
+package volume
+
+// Matrix is an array of Volumes
+type Matrix struct {
+	StaticMatrix
+	Channels int
+}
+
+// Apply takes a volume matrix and multiplies it by incoming volumes
+func (m Matrix) ApplyToMatrix(mtx Matrix) Matrix {
+	if m.Channels == mtx.Channels {
+		// simple straight-through
+		out := Matrix{
+			Channels: m.Channels,
+		}
+		for i := 0; i < m.Channels; i++ {
+			out.StaticMatrix[i] = mtx.StaticMatrix[i].ApplySingle(m.StaticMatrix[i])
+		}
+		return out
+	}
+
+	// more complex applications follow...
+
+	if mtx.Channels == 1 {
+		// right (mtx) is mono, so just do direct mono application
+		return m.Apply(m.StaticMatrix[0])
+	}
+
+	out := Matrix{
+		Channels: m.Channels,
+	}
+
+	switch m.Channels {
+	case 1:
+		// left (m) is mono, so do indirect mono application
+		mo := mtx.AsMono()
+		out.StaticMatrix[0] = m.StaticMatrix[0].ApplySingle(mo[0])
+		return out
+	case 2:
+		// left (m) is stereo, so do indirect stereo application
+		st := mtx.AsStereo()
+		out.StaticMatrix[0] = m.StaticMatrix[0].ApplySingle(st[0])
+		out.StaticMatrix[1] = m.StaticMatrix[1].ApplySingle(st[1])
+	case 4:
+		// left (m) is quad, so do indirect quad application
+		qu := mtx.AsQuad()
+		out.StaticMatrix[0] = m.StaticMatrix[0].ApplySingle(qu[0])
+		out.StaticMatrix[1] = m.StaticMatrix[1].ApplySingle(qu[1])
+		out.StaticMatrix[2] = m.StaticMatrix[2].ApplySingle(qu[2])
+		out.StaticMatrix[3] = m.StaticMatrix[3].ApplySingle(qu[3])
+	}
+	return out
+}
+
+func (m Matrix) Apply(vol Volume) Matrix {
+	var out Matrix
+	out.Channels = m.Channels
+	for i := 0; i < m.Channels; i++ {
+		out.StaticMatrix[i] = vol.ApplySingle(m.StaticMatrix[i])
+	}
+	return out
+}
+
+func (m *Matrix) Accumulate(in Matrix) {
+	if m.Channels == 0 {
+		m.Channels = in.Channels
+		copy(m.StaticMatrix[:m.Channels], in.StaticMatrix[:m.Channels])
+		return
+	}
+
+	var dry StaticMatrix
+	in.ToChannels(m.Channels, dry[:])
+	for i := 0; i < m.Channels; i++ {
+		m.StaticMatrix[i] += dry[i]
+	}
+}
+
+func (m *Matrix) Assign(channels int, data []Volume) {
+	m.Channels = channels
+	for i := 0; i < channels; i++ {
+		m.StaticMatrix[i] = data[i]
+	}
+}
+
+func (m Matrix) ToChannels(channels int, out []Volume) {
+	if m.Channels == channels {
+		copy(out, m.StaticMatrix[0:channels])
+		return
+	}
+
+	switch channels {
+	default:
+		copy(out, m.StaticMatrix[0:channels])
+	case 1:
+		mo := m.AsMono()
+		copy(out, mo[:])
+	case 2:
+		st := m.AsStereo()
+		copy(out, st[:])
+	case 4:
+		qu := m.AsQuad()
+		copy(out, qu[:])
+	}
+}
+
+// Sum sums all the elements of the Matrix and returns the resulting Volume
+func (m Matrix) Sum() Volume {
+	var v Volume
+	for i := 0; i < m.Channels; i++ {
+		v += m.StaticMatrix[i]
+	}
+	return v
+}
+
+func (m *Matrix) Set(ch int, vol Volume) {
+	m.StaticMatrix[ch] = vol
+}
+
+func (m Matrix) Get(ch int) Volume {
+	return m.StaticMatrix[ch]
+}
+
+func (m Matrix) AsMono() [1]Volume {
+	var out [1]Volume
+	if m.Channels == 1 {
+		out[0] = m.StaticMatrix[0]
+	} else {
+		out[0] = m.Sum() / Volume(m.Channels)
+	}
+	return out
+}
+
+func (m Matrix) AsStereo() [2]Volume {
+	switch m.Channels {
+	case 1:
+		return [2]Volume{m.StaticMatrix[0], m.StaticMatrix[0]}
+	case 2:
+		return [2]Volume{m.StaticMatrix[0], m.StaticMatrix[1]}
+	default:
+		return [2]Volume{(m.StaticMatrix[0] + m.StaticMatrix[2]) / 2.0, (m.StaticMatrix[1] + m.StaticMatrix[3]) / 2.0}
+	}
+}
+
+func (m Matrix) AsQuad() [4]Volume {
+	switch m.Channels {
+	case 1:
+		return [4]Volume{m.StaticMatrix[0], m.StaticMatrix[0], m.StaticMatrix[0], m.StaticMatrix[0]}
+	case 2:
+		return [4]Volume{m.StaticMatrix[0], m.StaticMatrix[1], m.StaticMatrix[0], m.StaticMatrix[1]}
+	default:
+		return [4]Volume{m.StaticMatrix[0], m.StaticMatrix[1], m.StaticMatrix[2], m.StaticMatrix[3]}
+	}
+}

--- a/volume/staticmatrix.go
+++ b/volume/staticmatrix.go
@@ -1,0 +1,105 @@
+package volume
+
+// StaticMatrix is an array of Volumes
+type StaticMatrix [4]Volume
+
+func (m StaticMatrix) Channels() int {
+	return 4
+}
+
+// Apply takes a volume matrix and multiplies it by incoming volumes
+func (m StaticMatrix) ApplyToMatrix(mtx StaticMatrix) StaticMatrix {
+	return StaticMatrix{
+		mtx[0].ApplySingle(m[0]),
+		mtx[1].ApplySingle(m[1]),
+		mtx[2].ApplySingle(m[2]),
+		mtx[3].ApplySingle(m[3]),
+	}
+}
+
+func (m StaticMatrix) Apply(vol Volume) StaticMatrix {
+	return StaticMatrix{
+		vol.ApplySingle(m[0]),
+		vol.ApplySingle(m[1]),
+		vol.ApplySingle(m[2]),
+		vol.ApplySingle(m[3]),
+	}
+}
+
+func (m *StaticMatrix) Accumulate(in StaticMatrix) {
+	m[0] += in[0]
+	m[1] += in[1]
+	m[2] += in[2]
+	m[3] += in[3]
+}
+
+func (m *StaticMatrix) Assign(channels int, data []Volume) {
+	switch channels {
+	case 1:
+		v := data[0]
+		m[0] = v
+		m[1] = v
+		m[2] = v
+		m[3] = v
+	case 2:
+		l := data[0]
+		r := data[1]
+		m[0] = l
+		m[1] = r
+		m[2] = l
+		m[3] = r
+	case 3:
+		l := data[0]
+		r := data[1]
+		cr := data[2]
+		m[0] = l
+		m[1] = r
+		m[2] = cr
+		m[3] = cr
+	case 4:
+		m[0] = data[0]
+		m[1] = data[1]
+		m[2] = data[2]
+		m[3] = data[3]
+	}
+}
+
+func (m StaticMatrix) ToChannels(channels int) []Volume {
+	switch channels {
+	default:
+		return nil
+	case 1:
+		return []Volume{m.Sum() / 4.0}
+	case 2:
+		l := (m[0] + m[2]) / 2.0
+		r := (m[1] + m[3]) / 2.0
+		return []Volume{l, r}
+	case 4:
+		return m[:]
+	}
+}
+
+// Sum sums all the elements of the StaticMatrix and returns the resulting Volume
+func (m StaticMatrix) Sum() Volume {
+	return m[0] + m[1] + m[2] + m[3]
+}
+
+func (m *StaticMatrix) Set(ch int, vol Volume) {
+	m[ch] = vol
+}
+
+func (m StaticMatrix) Get(ch int) Volume {
+	return m[ch]
+}
+
+func (m StaticMatrix) AsMono() [1]Volume {
+	return [1]Volume{(m[0] + m[1] + m[2] + m[3]) / 4.0}
+}
+
+func (m StaticMatrix) AsStereo() [2]Volume {
+	return [2]Volume{(m[0] + m[2]) / 2.0, (m[1] + m[3]) / 2.0}
+}
+
+func (m StaticMatrix) AsQuad() [4]Volume {
+	return m
+}

--- a/volume/volume.go
+++ b/volume/volume.go
@@ -1,6 +1,8 @@
 package volume
 
-import "math"
+import (
+	"math"
+)
 
 // Volume is a mixable volume
 type Volume float32
@@ -10,9 +12,6 @@ var (
 	// This is useful for trackers and other musical applications
 	VolumeUseInstVol = Volume(math.Inf(-1))
 )
-
-// Matrix is an array of Volumes
-type Matrix []Volume
 
 // Int24 is an approximation of a 24-bit integer
 type Int24 struct {
@@ -53,41 +52,18 @@ func (v Volume) ToIntSample(bitsPerSample int) int32 {
 	return 0
 }
 
-// Apply multiplies the volume to 0..n samples, then returns an array of the results
-func (v Volume) Apply(samp ...Volume) Matrix {
-	o := make(Matrix, len(samp))
+// Apply multiplies the volume to 1 sample, then returns the results
+func (v Volume) ApplySingle(samp Volume) Volume {
+	return samp * v
+}
+
+// Apply multiplies the volume to 1 sample, then returns the results
+func (v Volume) ApplyMultiple(samp []Volume) []Volume {
+	vols := make([]Volume, len(samp))
 	for i, s := range samp {
-		o[i] = s * v
+		vols[i] = s.ApplySingle(v)
 	}
-	return o
-}
-
-// Apply takes a volume matrix and multiplies it by incoming volumes
-func (m Matrix) Apply(samp ...Volume) Matrix {
-	o := make(Matrix, len(m))
-	v := Matrix(samp).Sum()
-	for i, s := range v.Apply(m...) {
-		o[i] = s
-	}
-	return o
-}
-
-// ApplyInSitu takes a volume matrix and multiplies it by incoming volumes
-func (m Matrix) ApplyInSitu(samp ...Volume) Matrix {
-	v := Matrix(samp).Sum()
-	for i, s := range v.Apply(m...) {
-		m[i] = s
-	}
-	return m
-}
-
-// Sum sums all the elements of the Matrix and returns the resulting Volume
-func (m Matrix) Sum() Volume {
-	var v Volume
-	for _, s := range m {
-		v += s
-	}
-	return v
+	return vols
 }
 
 func (v Volume) withOverflowProtection() float64 {


### PR DESCRIPTION
## Fixed or Changed
- Upgrade to go 1.18
- Reduce memory allocs by making Matrix  and PanMixer use static buffers